### PR TITLE
add support for geometry

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ development =
     mock
     pytz
     numpy
+    shapely
 pandas =
     snowflake-connector-python[pandas]<4.0.0
 

--- a/src/snowflake/sqlalchemy/__init__.py
+++ b/src/snowflake/sqlalchemy/__init__.py
@@ -49,6 +49,7 @@ from .custom_types import (
     DOUBLE,
     FIXED,
     GEOGRAPHY,
+    GEOMETRY,
     NUMBER,
     OBJECT,
     STRING,

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -654,5 +654,7 @@ class SnowflakeTypeCompiler(compiler.GenericTypeCompiler):
     def visit_GEOGRAPHY(self, type_, **kw):
         return "GEOGRAPHY"
 
+    def visit_GEOMETRY(self, type_, **kw):
+        return "GEOMETRY"
 
 construct_arguments = [(Table, {"clusterby": None})]

--- a/src/snowflake/sqlalchemy/custom_types.py
+++ b/src/snowflake/sqlalchemy/custom_types.py
@@ -33,20 +33,20 @@ class SnowflakeType(sqltypes.TypeEngine):
         return __import__("snowflake.sqlalchemy").sqlalchemy.dialect()
 
 
-class VARIANT(SnowflakeType):
-    __visit_name__ = "VARIANT"
-
-
-class OBJECT(SnowflakeType):
-    __visit_name__ = "OBJECT"
-
-
 class ARRAY(SnowflakeType):
     __visit_name__ = "ARRAY"
 
 
-class TIMESTAMP_TZ(SnowflakeType):
-    __visit_name__ = "TIMESTAMP_TZ"
+class GEOGRAPHY(SnowflakeType):
+    __visit_name__ = "GEOGRAPHY"
+
+
+class GEOMETRY(SnowflakeType):
+    __visit_name__ = "GEOMETRY"
+
+
+class OBJECT(SnowflakeType):
+    __visit_name__ = "OBJECT"
 
 
 class TIMESTAMP_LTZ(SnowflakeType):
@@ -57,8 +57,12 @@ class TIMESTAMP_NTZ(SnowflakeType):
     __visit_name__ = "TIMESTAMP_NTZ"
 
 
-class GEOGRAPHY(SnowflakeType):
-    __visit_name__ = "GEOGRAPHY"
+class TIMESTAMP_TZ(SnowflakeType):
+    __visit_name__ = "TIMESTAMP_TZ"
+
+
+class VARIANT(SnowflakeType):
+    __visit_name__ = "VARIANT"
 
 
 class _CUSTOM_Date(SnowflakeType, sqltypes.Date):

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -51,6 +51,7 @@ from .custom_types import (
     _CUSTOM_DECIMAL,
     ARRAY,
     GEOGRAPHY,
+    GEOMETRY,
     OBJECT,
     TIMESTAMP_LTZ,
     TIMESTAMP_NTZ,
@@ -71,6 +72,7 @@ colspecs = {
 }
 
 ischema_names = {
+    "ARRAY": ARRAY,
     "BIGINT": BIGINT,
     "BINARY": BINARY,
     # 'BIT': BIT,
@@ -83,11 +85,13 @@ ischema_names = {
     "DECIMAL": DECIMAL,
     "DOUBLE": FLOAT,
     "FIXED": DECIMAL,
+    "GEOGRAPHY": GEOGRAPHY,
+    "GEOMETRY": GEOMETRY,
     "FLOAT": FLOAT,
     "INT": INTEGER,
     "INTEGER": INTEGER,
     "NUMBER": _CUSTOM_DECIMAL,
-    # 'OBJECT': ?
+    "OBJECT": OBJECT,
     "REAL": REAL,
     "BYTEINT": SMALLINT,
     "SMALLINT": SMALLINT,
@@ -95,16 +99,13 @@ ischema_names = {
     "TEXT": VARCHAR,
     "TIME": TIME,
     "TIMESTAMP": TIMESTAMP,
-    "TIMESTAMP_TZ": TIMESTAMP_TZ,
     "TIMESTAMP_LTZ": TIMESTAMP_LTZ,
     "TIMESTAMP_NTZ": TIMESTAMP_NTZ,
+    "TIMESTAMP_TZ": TIMESTAMP_TZ,
     "TINYINT": SMALLINT,
     "VARBINARY": BINARY,
     "VARCHAR": VARCHAR,
     "VARIANT": VARIANT,
-    "OBJECT": OBJECT,
-    "ARRAY": ARRAY,
-    "GEOGRAPHY": GEOGRAPHY,
 }
 
 

--- a/tests/test_custom_types.py
+++ b/tests/test_custom_types.py
@@ -15,6 +15,7 @@ def test_string_conversions():
         "TIMESTAMP_LTZ",
         "TIMESTAMP_NTZ",
         "GEOGRAPHY",
+        "GEOMETRY"
     ]
     sf_types = [
         "TEXT",

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from json import loads
+
+from shapely.geometry import Point, MultiPolygon
+from sqlalchemy import Column, Integer, MetaData, Table
+from sqlalchemy.sql import select
+
+from snowflake.sqlalchemy import GEOMETRY
+
+
+def test_create_table_geometry_datatypes(engine_testaccount):
+    """
+    Create table including geometry data types
+    """
+
+    metadata = MetaData()
+    table_name = "test_geometry0"
+    test_geometry = Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("geom", GEOMETRY),
+    )
+    metadata.create_all(engine_testaccount)
+    try:
+        assert test_geometry is not None
+    finally:
+        test_geometry.drop(engine_testaccount)
+
+
+def test_inspect_geometry_datatypes(engine_testaccount):
+    """
+    Create table including geometry data types
+    """
+    metadata = MetaData()
+    table_name = "test_geometry0"
+    test_geometry = Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("geom1", GEOMETRY),
+        Column("geom2", GEOMETRY),
+    )
+    metadata.create_all(engine_testaccount)
+
+    try:
+        with engine_testaccount.connect() as conn:
+            test_point = Point([-94.584, 39.089])
+            test_multipolygon = MultiPolygon(
+                [
+                    ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)),
+                    ((0.1, 0.1), (0.1, 0.2), (0.2, 0.2), (0.2, 0.1)),
+                ]
+            )
+
+            ins = test_geometry.insert().values(
+                id=1, geom1=test_point, geom2=test_multipolygon
+            )
+
+            with conn.begin():
+                results = conn.execute(ins)
+                results.close()
+
+                s = select(test_geometry)
+                results = conn.execute(s)
+                rows = results.fetchone()
+                results.close()
+                assert rows[0] == 1
+                assert rows[1] == test_point.wkb_hex
+                assert rows[2] == test_multipolygon.wkb_hex
+    finally:
+        test_geometry.drop(engine_testaccount)


### PR DESCRIPTION
This PR adds support for the `GEOMETRY` data type to snowflake sqlalchemy connector.  It is necessary to support harmonization in snowflake [[PFP-4178](https://mysidewalk.atlassian.net/browse/PFP-4178)]. I closely followed this example: https://github.com/snowflakedb/snowflake-sqlalchemy/pull/271 

An item that I might need some help on:
 - I couldn't figure out how to run the tests.  [Their documentation](https://github.com/snowflakedb/snowflake-sqlalchemy/blob/main/tests/README.rst) includes making a parameters.py file with credentials to a snowflake instance.  I tried adding a test schema to the propdata database and using my user's credentials, but it didn't work.  Are they depending on a snowflake database that has a certain state to run the tests?

I'm guessing we'll want to open a PR against the base repo when we get this testing situation figured out.  We may want to release our own version on our private pypi server in the meanwhile if it takes them some time to include the change in a release.

---

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   TBD

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [x] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Change adds support for the `GEOMETRY` data type


[PFP-4178]: https://mysidewalk.atlassian.net/browse/PFP-4178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ